### PR TITLE
use the updated appdir to avoid panic on linux

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c8162574ccf8f39d1de2307f3193d7876aeb6599b3eb4f43c02bef95749a2c6c
-updated: 2017-12-01T08:22:37.841656-06:00
+hash: 1eb52d4789ec2bf35f7481739849b3fb9acd06cdabcf7c484115761186895ee1
+updated: 2018-03-20T01:32:39.485426-07:00
 imports:
 - name: git.torproject.org/pluggable-transports/goptlib.git
   version: a3ad5df6c9e7dc8117f55958b4ce99bf1e0fe291
@@ -30,7 +30,7 @@ imports:
 - name: github.com/dustin/go-humanize
   version: bb3d318650d48840a39aa21a027c6630e198e626
 - name: github.com/getlantern/appdir
-  version: 659a155d06e8f3dd8b9f79d6147445897499b56b
+  version: d1a26082a4196185d59bf52eb23d4ea2588c8838
 - name: github.com/getlantern/bandwidth
   version: 96de96fff16cf1aa844edc1b4a72c906add83180
 - name: github.com/getlantern/borda
@@ -168,6 +168,8 @@ imports:
   version: eae9b3e628d72774e13bdf024e78c0802f85a5b9
 - name: github.com/klauspost/reedsolomon
   version: e52c150f961e65ab9538bf1276b33bf469f919d8
+- name: github.com/mitchellh/go-homedir
+  version: b8bc1bf767474819792c23f32d8286a45736f1c6
 - name: github.com/mitchellh/mapstructure
   version: 06020f85339e21b2478f756a78e295255ffa4d6a
 - name: github.com/oschwald/geoip2-golang

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,3 +5,4 @@ import:
   subpackages:
   - client
 - package: github.com/getlantern/golog
+- package: github.com/mitchellh/go-homedir


### PR DESCRIPTION
For https://github.com/getlantern/lantern-internal/issues/1661. It simply includes https://github.com/getlantern/appdir/pull/1