### PR TITLE
add ability to check several times in a connection

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -265,7 +265,7 @@
 
 [[projects]]
   branch = "devel"
-  digest = "1:33bc078e7018d7e785ad8a62949ea5ed03ba86e37d590016088b0bd4462a69e2"
+  digest = "1:017e00c9b620cbeb5c65d9210eeb330c39a22a8e1f3a08387a25524ae1563f3c"
   name = "github.com/getlantern/flashlight"
   packages = [
     "balancer",
@@ -284,7 +284,7 @@
     "status",
   ]
   pruneopts = "UT"
-  revision = "c7fd7392d0bb888075ec36cad28695f028eec94d"
+  revision = "a194e6cacf810b84ce52509a64a6ab090faa5838"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,8 +1,4 @@
 [[constraint]]
-  branch = "master"
-  name = "github.com/getlantern/errors"
-
-[[constraint]]
   branch = "devel"
   name = "github.com/getlantern/flashlight"
 

--- a/checkfallbacks.go
+++ b/checkfallbacks.go
@@ -69,8 +69,11 @@ func main() {
 	fallbacks := loadFallbacks(*fallbacksFile)
 	outputCh := testAllFallbacks(fallbacks)
 	for out := range outputCh {
+		// Scripts in lanter_aws repo expect the output formats below.
 		if out.err != nil {
 			fmt.Printf("[failed fallback check] %v\n", out.err)
+		} else {
+			fmt.Printf("Fallback %s OK.\n", out.addr)
 		}
 		if *verbose && len(out.info) > 0 {
 			for _, msg := range out.info {
@@ -148,6 +151,7 @@ func loadFallbacks(filename string) (fallbacks [][]chained.ChainedServerInfo) {
 }
 
 type fullOutput struct {
+	addr string
 	err  error
 	info []string
 }
@@ -199,7 +203,7 @@ func testAllFallbacks(fallbacks [][]chained.ChainedServerInfo) (output chan *ful
 
 // Perform the test of an individual server
 func testFallbackServer(fb *chained.ChainedServerInfo, workerID int) (output *fullOutput) {
-	output = &fullOutput{}
+	output = &fullOutput{addr: fb.Addr}
 
 	proto := "http"
 	if fb.Cert != "" {


### PR DESCRIPTION
Verified on the China VPS that it can detect blocking described [here](https://github.com/getlantern/lantern-internal/issues/2619#issuecomment-463183228): Adding `-checks 3` makes previously passing proxy fail because subsequent packets in a connection being dropped.

```
23:03:12.979860 IP 10.105.255.88.42858 > 128.199.197.215.https: Flags [S], seq 547790047, win 29200, options [mss 1460,sackOK,TS val 1312875296 ecr 0,nop,wscale 7], length 0
23:03:13.240251 IP 128.199.197.215.https > 10.105.255.88.42858: Flags [S.], seq 2155130917, ack 547790048, win 28960, options [mss 1424,sackOK,TS val 1517546038 ecr 1312875296,nop,wscale 7], length 0
23:03:13.240295 IP 10.105.255.88.42858 > 128.199.197.215.https: Flags [.], ack 1, win 229, options [nop,nop,TS val 1312875361 ecr 1517546038], length 0
23:03:13.240835 IP 10.105.255.88.42858 > 128.199.197.215.https: Flags [P.], seq 1:516, ack 1, win 229, options [nop,nop,TS val 1312875362 ecr 1517546038], length 515
23:03:13.502504 IP 128.199.197.215.https > 10.105.255.88.42858: Flags [.], ack 516, win 235, options [nop,nop,TS val 1517546298 ecr 1312875362], length 0
23:03:13.507740 IP 128.199.197.215.https > 10.105.255.88.42858: Flags [P.], seq 1:74, ack 516, win 235, options [nop,nop,TS val 1517546304 ecr 1312875362], length 73
23:03:13.507772 IP 10.105.255.88.42858 > 128.199.197.215.https: Flags [.], ack 74, win 229, options [nop,nop,TS val 1312875428 ecr 1517546304], length 0
23:03:13.508520 IP 128.199.197.215.https > 10.105.255.88.42858: Flags [P.], seq 74:1373, ack 516, win 235, options [nop,nop,TS val 1517546305 ecr 1312875362], length 1299
23:03:13.508534 IP 10.105.255.88.42858 > 128.199.197.215.https: Flags [.], ack 1373, win 251, options [nop,nop,TS val 1312875429 ecr 1517546305], length 0
23:03:13.508759 IP 10.105.255.88.42858 > 128.199.197.215.https: Flags [P.], seq 516:775, ack 1373, win 251, options [nop,nop,TS val 1312875429 ecr 1517546305], length 259
23:03:14.096365 IP 10.105.255.88.42858 > 128.199.197.215.https: Flags [P.], seq 516:775, ack 1373, win 251, options [nop,nop,TS val 1312875576 ecr 1517546305], length 259
23:03:14.876362 IP 10.105.255.88.42858 > 128.199.197.215.https: Flags [P.], seq 516:775, ack 1373, win 251, options [nop,nop,TS val 1312875771 ecr 1517546305], length 259
23:03:16.440362 IP 10.105.255.88.42858 > 128.199.197.215.https: Flags [P.], seq 516:775, ack 1373, win 251, options [nop,nop,TS val 1312876162 ecr 1517546305], length 259
23:03:19.568371 IP 10.105.255.88.42858 > 128.199.197.215.https: Flags [P.], seq 516:775, ack 1373, win 251, options [nop,nop,TS val 1312876944 ecr 1517546305], length 259
23:03:25.824371 IP 10.105.255.88.42858 > 128.199.197.215.https: Flags [P.], seq 516:775, ack 1373, win 251, options [nop,nop,TS val 1312878508 ecr 1517546305], length 259
23:03:38.320377 IP 10.105.255.88.42858 > 128.199.197.215.https: Flags [P.], seq 516:775, ack 1373, win 251, options [nop,nop,TS val 1312881632 ecr 1517546305], length 259
23:04:03.344391 IP 10.105.255.88.42858 > 128.199.197.215.https: Flags [P.], seq 516:775, ack 1373, win 251, options [nop,nop,TS val 1312887888 ecr 1517546305], length 259
23:04:13.509939 IP 10.105.255.88.42858 > 128.199.197.215.https: Flags [FP.], seq 775:1336, ack 1373, win 251, options [nop,nop,TS val 1312890429 ecr 1517546305], length 561
23:04:28.541093 IP 128.199.197.215.https > 10.105.255.88.42858: Flags [F.], seq 1373, ack 516, win 235, options [nop,nop,TS val 1517621302 ecr 1312875429], length 0
```